### PR TITLE
Update nix version to 0.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ windows-service = "0.7.0"
 tokio = { version = "1.43.0", features = ["full"] }
 serde = { version = "1.0.217", features = ["derive"] }
 sysinfo = "0.33.1"
-nix = "0.25.1"
+nix = { version = "0.29.0", features = ["signal"] }
 libc = "0.2.169"
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
Update to nix v0.29.0 to support loongarch64 machine.

This commit is inspired by https://github.com/AOSC-Dev/aosc-os-abbs/commit/cdd75373616423739de60c33aa1a4d08328d5d8e .

Fix https://github.com/clash-verge-rev/clash-verge-service/issues/4 .